### PR TITLE
Add maven plugin to build release on jitpack.io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 subprojects {
+    apply plugin: 'maven'
     apply plugin: 'java'
     apply from: '../codeQuality.gradle'
 


### PR DESCRIPTION
Instead of complex setup for releasing `logw` to jcenter or maven central embrace the power of github releases and use https://jitpack.io/

Jitpacks uses github releases for artifact deployment. Using the latest (or any git commit) enables developers to get any version without handling snapshot repositories. Just change the versionnumber to the git commit id and everything is fine. If you're ok with that I'll remove `jcenter` and update the readme afterwards.

Readme: https://jitpack.io/
