### PR TITLE
Use project properties for to keep sub build scripts small

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ configure(subprojects - project(':benchmark')) {
 
 //    archiveTask.extension = org.gradle.api.tasks.bundling.Jar
 
+    jar {
+        manifest.attributes 'Implementation-Title': project.name
+    }
+    
     task javadocJar(type: Jar) {
         classifier = 'javadoc'
         from javadoc

--- a/logw-core/build.gradle
+++ b/logw-core/build.gradle
@@ -1,8 +1,4 @@
 
-jar {
-    manifest.attributes 'Implementation-Title': 'logw'
-}
-
 dependencies {
     // TODO: Slf4j is needed for the MessageFormatter, remove this dependency.
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.12'

--- a/logw-log4j2/build.gradle
+++ b/logw-log4j2/build.gradle
@@ -1,6 +1,3 @@
-jar {
-    manifest.attributes 'Implementation-Title': 'logw-log4j2'
-}
 
 dependencies {
     compile project(':logw-core')

--- a/logw-slf4j/build.gradle
+++ b/logw-slf4j/build.gradle
@@ -1,8 +1,4 @@
 
-jar {
-    manifest.attributes 'Implementation-Title': 'logw-slf4j'
-}
-
 dependencies {
     compile project(':logw-core')
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.12'


### PR DESCRIPTION
Moved manifest configuration to main build file using common project properties. 

@sajato What about the upload and deployment stuff? Can we use the same mechanism for it? 
