### PR TITLE
fix broken test

### DIFF
--- a/logw-core/src/test/java/eu/sajato/logw/LogwTest.java
+++ b/logw-core/src/test/java/eu/sajato/logw/LogwTest.java
@@ -32,7 +32,7 @@ public class LogwTest {
     public void warnParameterTest(){
 
         new NonStrictExpectations(){{
-            loggingWrapper.log(anyString, Level.WARN, "Hello Test");
+            loggingWrapper.log(anyString, Level.WARN, "Hello World");
             times = 1;
 
             loggingWrapper.isLoggable(anyString, Level.WARN);
@@ -40,7 +40,9 @@ public class LogwTest {
         }};
 
         Logw.setInnerLogger(loggingWrapper);
-        Logw.warn("Hello {}", "Test");
+
+        Object[] arguments = {"World"};
+        Logw.warn("Hello {}", arguments);
     }
 
     @Test


### PR DESCRIPTION
I've fixed the broken build. There seems to be a method signature clash. When calling

`Logw.warn("Hello {}", "World");` this can be 

``` java
warn(String messagePattern, Object... arguments)
```

or

``` java
warn(String loggerName, String messagePattern, Object... arguments)
```

with no arguments.
